### PR TITLE
dj/fix eq for dna string slice

### DIFF
--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,6 +460,12 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
+
+        println!( "entering eq of {}, start = {}, length = {}, is_rc = {} to \
+            {}, start = {}, length = {}, is_rc = {}",
+            self.dna_string.to_string(), self.start, self.length, self.is_rc,
+            other.dna_string.to_string(), other.start, other.length, other.is_rc );
+
         let n = self.length;
         if other.length != n { return false; }
         for i in 0..n {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -478,8 +478,8 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         }
         else {
             for i in 0..n {
-                if ( self.get( self.start + i ) 
-                        + other.get( other.start + n - i - 1 ) ) % 4 != 3 { 
+                if self.get( self.start + i ) 
+                        != ::complement( other.get( other.start + n - i - 1 ) ) { 
 
                     // XXX:
                     println!( "eq-rc returning false for {} and {}, whose actual\

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -463,9 +463,18 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         let n = self.length;
         if other.length != n { return false; }
         for i in 0..n {
-            if self.dna_string.get( self.start + i ) 
-                != other.dna_string.get( other.start + i ) { 
-                return false; 
+            if self.is_rc == other.is_rc {
+                if self.dna_string.get( self.start + i ) 
+                    != other.dna_string.get( other.start + i ) { 
+                    return false; 
+                }
+            }
+            else {
+                if self.dna_string.get( self.start + i ) 
+                    != ::complement( other.dna_string.get( 
+                        other.start + other.length - i - 1 ) ) { 
+                    return false; 
+                }
             }
         }
         true

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,12 +460,18 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
-        println!( "ENTERING EQ" ); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         let n = self.len();
-        if other.length != n{ return false; }
+        if other.length != n { return false; }
         if self.is_rc == other.is_rc {
             for i in 0..n {
                 if self.get( self.start + i ) != other.get( other.start + i ) { 
+
+                    // XXX:
+                    println!( "eq returning false for {} and {}, whose actual\
+                        equality is {}",
+                        self.to_string(), other.to_string(),
+                        self.to_string() == other.to_string() );
+
                     return false; 
                 }
             }
@@ -474,10 +480,23 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
             for i in 0..n {
                 if ( self.get( self.start + i ) 
                         + other.get( other.start + n - i - 1 ) ) % 4 != 3 { 
+
+                    // XXX:
+                    println!( "eq-rc returning false for {} and {}, whose actual\
+                        equality is {}",
+                        self.to_string(), other.to_string(),
+                        self.to_string() == other.to_string() );
+
                     return false; 
                 }
             }
         }
+
+        // XXX:
+        println!( "eq returning true for {} and {}, whose actual equality is {}",
+            self.to_string(), other.to_string(),
+            self.to_string() == other.to_string() );
+
         true
     }
 }

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -469,7 +469,8 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         let n = self.length;
         if other.length != n { return false; }
         for i in 0..n {
-            if self.get( self.start + i ) != other.get( other.start + i ) { 
+            if self.dna_string.get( self.start + i ) 
+                != other.dna_string.get( other.start + i ) { 
                 return false; 
             }
         }

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,6 +460,7 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
+        println!( "ENTERING EQ" ); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         let n = self.len();
         if other.length != n{ return false; }
         if self.is_rc == other.is_rc {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,8 +460,17 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
-        let n = self.len();
+        let n = self.length;
+
         if other.length != n { return false; }
+
+        println!( "\nn = {}", n );
+        println!( "self.is_rc = {}", self.is_rc );
+        println!( "other.is_rc = {}", other.is_rc );
+        for i in 0..n {
+            println!( "{} vs {}", self.get(i), other.get(i) );
+        }
+
         if self.is_rc == other.is_rc {
             for i in 0..n {
                 if self.get( self.start + i ) != other.get( other.start + i ) { 

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -471,7 +471,7 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
             println!( "{} vs {}", self.get(i), other.get(i) );
         }
 
-        if self.is_rc == other.is_rc {
+        // if self.is_rc == other.is_rc {
             for i in 0..n {
                 if self.get( self.start + i ) != other.get( other.start + i ) { 
 
@@ -484,7 +484,8 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
                     return false; 
                 }
             }
-        }
+        // }
+        /*
         else {
             for i in 0..n {
                 if self.get( self.start + i ) 
@@ -500,6 +501,7 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
                 }
             }
         }
+        */
 
         // XXX:
         println!( "eq returning true for {}.{} and {}.{}, \

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,6 +460,19 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
+        if other.length != self.length { return false; }
+        for i in 0..self.length {
+            if self.get( self.start + i ) != other.get( other.start + i ) {
+                return false
+            }
+        }
+        true
+    }
+}
+
+/*
+impl<'a> PartialEq for DnaStringSlice<'a> {
+    fn eq( &self, other: &DnaStringSlice ) -> bool {
         let n = self.length;
         if other.length != n { return false; }
         for i in 0..n {
@@ -480,6 +493,8 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         true
     }
 }
+*/
+
 impl<'a> Eq for DnaStringSlice<'a> { }
 
 impl<'a> Mer for DnaStringSlice<'a> {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -467,32 +467,6 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         true
     }
 }
-
-/*
-impl<'a> PartialEq for DnaStringSlice<'a> {
-    fn eq( &self, other: &DnaStringSlice ) -> bool {
-        let n = self.length;
-        if other.length != n { return false; }
-        for i in 0..n {
-            if self.is_rc == other.is_rc {
-                if self.dna_string.get( self.start + i ) 
-                    != other.dna_string.get( other.start + i ) { 
-                    return false; 
-                }
-            }
-            else {
-                if self.dna_string.get( self.start + i ) 
-                    != ::complement( other.dna_string.get( 
-                        other.start + other.length - i - 1 ) ) { 
-                    return false; 
-                }
-            }
-        }
-        true
-    }
-}
-*/
-
 impl<'a> Eq for DnaStringSlice<'a> { }
 
 impl<'a> Mer for DnaStringSlice<'a> {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -450,7 +450,7 @@ impl<'a> IntoIterator for &'a DnaString {
 
 
 /// An immutable slice into a DnaString
-#[derive(Eq, PartialEq, Clone)]
+#[derive(Clone)]
 pub struct DnaStringSlice<'a> {
     pub dna_string: &'a DnaString,
     pub start: usize,
@@ -458,6 +458,29 @@ pub struct DnaStringSlice<'a> {
     pub is_rc: bool,
 }
 
+impl<'a> PartialEq for DnaStringSlice<'a> {
+    fn eq( &self, other: &DnaStringSlice ) -> bool {
+        let n = self.len();
+        if other.length != n{ return false; }
+        if self.is_rc == other.is_rc {
+            for i in 0..n {
+                if self.get( self.start + i ) != other.get( other.start + i ) { 
+                    return false; 
+                }
+            }
+        }
+        else {
+            for i in 0..n {
+                if ( self.get( self.start + i ) 
+                        + other.get( other.start + n - i - 1 ) ) % 4 != 3 { 
+                    return false; 
+                }
+            }
+        }
+        true
+    }
+}
+impl<'a> Eq for DnaStringSlice<'a> { }
 
 impl<'a> Mer for DnaStringSlice<'a> {
     fn len(&self) -> usize {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -461,10 +461,10 @@ pub struct DnaStringSlice<'a> {
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
 
-        println!( "entering eq of {}, start = {}, length = {}, is_rc = {} to \
-            {}, start = {}, length = {}, is_rc = {}",
-            self.dna_string.to_string(), self.start, self.length, self.is_rc,
-            other.dna_string.to_string(), other.start, other.length, other.is_rc );
+        println!( "entering eq of len = {}, start = {}, length = {}, is_rc = {} to \
+            len = {}, start = {}, length = {}, is_rc = {}",
+            self.dna_string.len(), self.start, self.length, self.is_rc,
+            other.dna_string.len(), other.start, other.length, other.is_rc );
 
         let n = self.length;
         if other.length != n { return false; }

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -460,12 +460,6 @@ pub struct DnaStringSlice<'a> {
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
-
-        println!( "entering eq of len = {}, start = {}, length = {}, is_rc = {} to \
-            len = {}, start = {}, length = {}, is_rc = {}",
-            self.dna_string.len(), self.start, self.length, self.is_rc,
-            other.dna_string.len(), other.start, other.length, other.is_rc );
-
         let n = self.length;
         if other.length != n { return false; }
         for i in 0..n {

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -461,54 +461,12 @@ pub struct DnaStringSlice<'a> {
 impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
         let n = self.length;
-
         if other.length != n { return false; }
-
-        println!( "\nn = {}", n );
-        println!( "self.is_rc = {}", self.is_rc );
-        println!( "other.is_rc = {}", other.is_rc );
         for i in 0..n {
-            println!( "{} vs {}", self.get(i), other.get(i) );
-        }
-
-        // if self.is_rc == other.is_rc {
-            for i in 0..n {
-                if self.get( self.start + i ) != other.get( other.start + i ) { 
-
-                    // XXX:
-                    println!( "eq returning false for {} and {}, whose actual\
-                        equality is {}",
-                        self.to_string(), other.to_string(),
-                        self.to_string() == other.to_string() );
-
-                    return false; 
-                }
-            }
-        // }
-        /*
-        else {
-            for i in 0..n {
-                if self.get( self.start + i ) 
-                        != ::complement( other.get( other.start + n - i - 1 ) ) { 
-
-                    // XXX:
-                    println!( "eq-rc returning false for {} and {}, whose actual\
-                        equality is {}",
-                        self.to_string(), other.to_string(),
-                        self.to_string() == other.to_string() );
-
-                    return false; 
-                }
+            if self.get( self.start + i ) != other.get( other.start + i ) { 
+                return false; 
             }
         }
-        */
-
-        // XXX:
-        println!( "eq returning true for {}.{} and {}.{}, \
-            whose actual equality is {}",
-            self.to_string(), self.is_rc, other.to_string(), other.is_rc,
-            self.to_string() == other.to_string() );
-
         true
     }
 }

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -493,8 +493,9 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
         }
 
         // XXX:
-        println!( "eq returning true for {} and {}, whose actual equality is {}",
-            self.to_string(), other.to_string(),
+        println!( "eq returning true for {}.{} and {}.{}, \
+            whose actual equality is {}",
+            self.to_string(), self.is_rc, other.to_string(), other.is_rc,
             self.to_string() == other.to_string() );
 
         true

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -462,9 +462,7 @@ impl<'a> PartialEq for DnaStringSlice<'a> {
     fn eq( &self, other: &DnaStringSlice ) -> bool {
         if other.length != self.length { return false; }
         for i in 0..self.length {
-            if self.get( self.start + i ) != other.get( other.start + i ) {
-                return false
-            }
+            if self.get(i) != other.get(i) { return false }
         }
         true
     }


### PR DESCRIPTION
Previously, checking equality of DnaStringSlices resulted in a default calculation that was incorrect.  This branch fixes that bug by adding an explicit equality operator.  This would likely change results for any code that tested equality of DnaStringSlices.   This branch was tested by seeing if 
( x == x.rc() ) == ( x.to_string() == x.rc().to_string() ) for a large number of DnaStringSlices x arising in VDJ assembly.