### PR TITLE
switch to updated boomphf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ pretty_assertions = "0.5"
 
 [dependencies.boomphf]
 git = "https://github.com/10XGenomics/rust-boomphf"
-version = ">=0.3.1"
+version = ">=0.4"
 branch = "master"
-features = ["serde", "fast-constructors"]
+features = ["serde"]
 
 [dependencies.concurrent-hashmap]
 version = "0.2.1"

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -218,10 +218,7 @@ impl DnaString {
         let mut hasher = DefaultHasher::new();
         read_name.hash(&mut hasher);
         
-        let mut dna_string = DnaString {
-            storage: Vec::new(),
-            len: 0,
-        };
+        let mut dna_string = DnaString::empty(bytes.len());
 
         for (pos, c) in bytes.iter().enumerate() {
 
@@ -283,6 +280,7 @@ impl DnaString {
     }
 
     /// Append a 0-4 encoded base.
+    #[inline]
     pub fn push(&mut self, value: u8) {
         let (block, bit) = self.addr(self.len);
         if bit == 0 && block >= self.storage.len() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -18,7 +18,6 @@ use std::io::Error;
 use std::hash::Hash;
 use std::f32;
 
-use boomphf::FastIterator;
 use boomphf::hashmap::BoomHashMap;
 
 use serde_json;
@@ -300,13 +299,20 @@ impl<K: Kmer, D: Debug> DebruijnGraph<K, D> {
                     let ret_edges = next.edges(return_dir);
                     if ret_edges.len() == 1 {
 
+                        // Test for us being a palindrome
                         if n.len() == K::k() && n.sequence().first_kmer::<K>().is_palindrome()
                         {
                             return None;
                         }
 
+                        // Test for a neighbor being a palindrome
                         if next.len() == K::k() && next.sequence().first_kmer::<K>().is_palindrome()
                         {
+                            return None;
+                        }
+
+                        // Test for this edge representing a smooth circle (biting it's own tail)
+                        if n.node_id == next_id {
                             return None;
                         }
 
@@ -1006,14 +1012,17 @@ impl<'a, K: Kmer + 'a, D: Debug + 'a> Iterator for NodeKmerIter<'a, K, D> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         return (self.num_kmers, Some(self.num_kmers))
     }
-}
 
-impl<'a, K: Kmer + 'a, D: Debug + 'a> FastIterator for NodeKmerIter<'a, K, D> {
-    fn skip_next(&mut self) {
-        self.kmer_id += 1;
+    /// Provide a 'fast-forward' capability for this iterator
+    /// MPHF will use this to reduce the number of kmers that 
+    /// need to be produced.
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.kmer_id += n;
+        self.next()
     }
 }
 
+/// Marker signifying that NodeKmerIter has a known size. 
 impl<'a, K: Kmer + 'a, D: Debug + 'a> ExactSizeIterator for NodeKmerIter<'a, K, D> {}
 
 /// Unbranched sequence in the DeBruijn graph


### PR DESCRIPTION
- Drop the FastIterator trait in favor of overloading Iterator::nth().
- Also fix an edge case in the `is_compressed()` check to allow smooth circles.
- 2 small optimizations.