### PR TITLE
add function ndiffs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bit-set = "0.4.0"
 itertools = ">=0.7"
 byteorder = "*"
 num = "0.2"
+lazy_static = "1.4"
 
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -50,7 +50,7 @@ const MASK: u64 = 0x3;
 /// A container for sequence of DNA bases.
 #[derive(Ord, PartialOrd, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DnaString {
-    pub storage: Vec<u64>,
+    storage: Vec<u64>,
     len: usize,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@
 //! which expects bases encoded as the integers 0,1,2,3, and a separate form names 'ascii',
 //! which expects bases encoded as the ASCII letters A,C,G,T.
 
+#[macro_use]
+extern crate lazy_static;
+
 use serde_derive::{Deserialize, Serialize};
 use std::hash::Hash;
 use std::fmt;


### PR DESCRIPTION
The function computes the number of differences between two DnaStrings of equal length.
It is a few times faster than computing base by base.