### PR TITLE
speed up ndiffs using code from Pat

### DIFF
--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -402,6 +402,11 @@ impl DnaString {
         dna_string
     }
 
+    /// Compute Hamming distance between this DnaString and another DnaString. The two strings must have the same length.
+    pub fn hamming_distance(&self, other: &DnaString) -> usize {
+        ndiffs(self, other)
+    }
+
     // pub fn complement(&self) -> DnaString {
     //    assert!(self.width == 2, "Complement only supported for 2bit encodings.");
     //    let values: Vec<u32> = Vec::with_capacity(self.len());
@@ -452,8 +457,9 @@ impl<'a> IntoIterator for &'a DnaString {
     }
 }
 
+/// count Hamming distance between 2 2-bit DNA packed u64s
 fn count_diff_2_bit_packed(a: u64, b: u64) -> usize {
-    let bit_diffs = (a ^ b);
+    let bit_diffs = a ^ b;
     let two_bit_diffs = (bit_diffs | bit_diffs >> 1) & 0x5555555555555555;
     let total_diffs = two_bit_diffs.count_ones() as usize;
     return total_diffs;
@@ -461,7 +467,6 @@ fn count_diff_2_bit_packed(a: u64, b: u64) -> usize {
 
 /// Compute the number of base positions at which two DnaStrings differ, assuming
 /// that they have the same length.
-
 pub fn ndiffs(b1: &DnaString, b2: &DnaString) -> usize {
     assert_eq!(b1.len(), b2.len());
     let mut diffs = 0;
@@ -833,6 +838,18 @@ mod tests {
         let x1 = DnaString::from_dna_string("TGCATTAGAAAACTCCTTGCCTGTCTAGAAACTCATTAATCCACACATTGA");
         let x2 = DnaString::from_dna_string("TGCATTAGTAAACTCCTTCGCTGTCTAGAAAATCATTAAGCCACACATTGA");
         assert!(ndiffs(&x1, &x2) == 5);
+
+        let x1 = DnaString::from_dna_string("TGCATT");
+        let x2 = DnaString::from_dna_string("TGCATT");
+        assert!(ndiffs(&x1, &x2) == 0);
+
+        let x1 = DnaString::from_dna_string("");
+        let x2 = DnaString::from_dna_string("");
+        assert!(ndiffs(&x1, &x2) == 0);
+
+        let x1 = DnaString::from_dna_string("TGCATTAGAAAACTCCTTGCCTGTCTAGAAACTCATTAATCCACACATTGATGCATTAGAAAACTCCTTGCCTGTCTAGAAACTCATTAATCCACACATTGATGCATTAGAAAACTCCTTGCCTGTCTAGAAACTCATTAATCCACACATTGA");
+        let x2 = DnaString::from_dna_string("TGCATTAGTAAACTCCTTCGCTGTCTAGAAAATCATTAAGCCACACATTGATGCATTAGTAAACTCCTTCGCTGTCTAGAAAATCATTAAGCCACACATTGATGCATTAGTAAACTCCTTCGCTGTCTAGAAAATCATTAAGCCACACATTGA");
+        assert!(ndiffs(&x1, &x2) == 15);
     }
 
     #[test]

--- a/src/dna_string.rs
+++ b/src/dna_string.rs
@@ -25,16 +25,16 @@
 //! let first_kmer: Kmer16 = slice1.get_kmer(0);
 //! assert_eq!(first_kmer, Kmer16::from_ascii(b"CACGTATGACAGATAG"))
 
-use std::fmt;
-use std::borrow::Borrow;
 use serde_derive::{Deserialize, Serialize};
+use std::borrow::Borrow;
 use std::cmp::min;
-use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::hash::{Hash, Hasher};
 
-use crate::bits_to_base;
 use crate::base_to_bits;
 use crate::bits_to_ascii;
+use crate::bits_to_base;
 use crate::dna_only_base_to_bits;
 
 use crate::Kmer;
@@ -85,8 +85,7 @@ impl Mer for DnaString {
     }
 }
 
-impl Vmer for DnaString
-{
+impl Vmer for DnaString {
     fn new(len: usize) -> Self {
         Self::blank(len)
     }
@@ -128,7 +127,6 @@ impl Vmer for DnaString
         kmer
     }
 }
-
 
 impl DnaString {
     /// Create an empty DNA string
@@ -205,7 +203,6 @@ impl DnaString {
         dna_vector
     }
 
-
     /// Create a DnaString from an ASCII ACGT-encoded byte slice.
     /// Non ACGT positions will be converted to 'A'
     pub fn from_acgt_bytes(bytes: &[u8]) -> DnaString {
@@ -225,14 +222,12 @@ impl DnaString {
     /// Non ACGT positions will be converted to repeatable random base determined
     /// by a hash of the read name and the position within the string.
     pub fn from_acgt_bytes_hashn(bytes: &[u8], read_name: &[u8]) -> DnaString {
-
         let mut hasher = DefaultHasher::new();
         read_name.hash(&mut hasher);
-        
+
         let mut dna_string = DnaString::with_capacity(bytes.len());
 
         for (pos, c) in bytes.iter().enumerate() {
-
             let v = match c {
                 b'A' | b'a' => 0u8,
                 b'C' | b'c' => 1u8,
@@ -242,7 +237,7 @@ impl DnaString {
                     let mut hasher_clone = hasher.clone();
                     pos.hash(&mut hasher_clone);
                     (hasher_clone.finish() % 4) as u8
-                    },
+                }
             };
 
             dna_string.push(v);
@@ -417,7 +412,6 @@ impl DnaString {
     // }
 }
 
-
 impl fmt::Debug for DnaString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
@@ -446,7 +440,6 @@ impl<'a> Iterator for DnaStringIter<'a> {
         } else {
             None
         }
-
     }
 }
 
@@ -459,18 +452,18 @@ impl<'a> IntoIterator for &'a DnaString {
     }
 }
 
-fn count_diff_2_bit_packed(a: u64, b: u64) ->  usize {
+fn count_diff_2_bit_packed(a: u64, b: u64) -> usize {
     let bit_diffs = (a ^ b);
     let two_bit_diffs = (bit_diffs | bit_diffs >> 1) & 0x5555555555555555;
     let total_diffs = two_bit_diffs.count_ones() as usize;
-    return total_diffs
+    return total_diffs;
 }
 
 /// Compute the number of base positions at which two DnaStrings differ, assuming
 /// that they have the same length.
 
-pub fn ndiffs( b1: &DnaString, b2: &DnaString ) -> usize {
-    assert_eq!( b1.len(), b2.len() );
+pub fn ndiffs(b1: &DnaString, b2: &DnaString) -> usize {
+    assert_eq!(b1.len(), b2.len());
     let mut diffs = 0;
     let (s1, s2) = (&b1.storage, &b2.storage);
     for i in 0..s1.len() {
@@ -489,15 +482,19 @@ pub struct DnaStringSlice<'a> {
 }
 
 impl<'a> PartialEq for DnaStringSlice<'a> {
-    fn eq( &self, other: &DnaStringSlice ) -> bool {
-        if other.length != self.length { return false; }
+    fn eq(&self, other: &DnaStringSlice) -> bool {
+        if other.length != self.length {
+            return false;
+        }
         for i in 0..self.length {
-            if self.get(i) != other.get(i) { return false }
+            if self.get(i) != other.get(i) {
+                return false;
+            }
         }
         true
     }
 }
-impl<'a> Eq for DnaStringSlice<'a> { }
+impl<'a> Eq for DnaStringSlice<'a> {}
 
 impl<'a> Mer for DnaStringSlice<'a> {
     fn len(&self) -> usize {
@@ -535,8 +532,7 @@ impl<'a> Mer for DnaStringSlice<'a> {
     }
 }
 
-impl<'a> Vmer for DnaStringSlice<'a>
-{
+impl<'a> Vmer for DnaStringSlice<'a> {
     fn new(_: usize) -> Self {
         unimplemented!()
     }
@@ -551,8 +547,6 @@ impl<'a> Vmer for DnaStringSlice<'a>
         self.dna_string.get_kmer(self.start + pos)
     }
 }
-
-
 
 impl<'a> DnaStringSlice<'a> {
     pub fn is_palindrome(&self) -> bool {
@@ -596,9 +590,12 @@ impl<'a> DnaStringSlice<'a> {
 
         be
     }
-        /// Get slice containing the interval [`start`, `end`) of `self`
+    /// Get slice containing the interval [`start`, `end`) of `self`
     pub fn slice(&self, start: usize, end: usize) -> DnaStringSlice<'_> {
-        assert!(start <= self.length, "coordinate exceeds number of elements.");
+        assert!(
+            start <= self.length,
+            "coordinate exceeds number of elements."
+        );
         assert!(end <= self.length, "coordinate exceeds number of elements.");
 
         DnaStringSlice {
@@ -608,7 +605,6 @@ impl<'a> DnaStringSlice<'a> {
             is_rc: false,
         }
     }
-
 }
 
 impl<'a> fmt::Debug for DnaStringSlice<'a> {
@@ -620,7 +616,11 @@ impl<'a> fmt::Debug for DnaStringSlice<'a> {
             }
             write!(f, "{}", s)
         } else {
-            write!(f, "start: {}, len: {}, is_rc: {}", self.start, self.length, self.is_rc)
+            write!(
+                f,
+                "start: {}, len: {}, is_rc: {}",
+                self.start, self.length, self.is_rc
+            )
         }
     }
 }
@@ -633,7 +633,6 @@ impl<'a> IntoIterator for &'a DnaStringSlice<'a> {
         self.iter()
     }
 }
-
 
 /// Container for many distinct sequences, concatenated into a single DnaString.  Each
 /// sequence is accessible by index as a DnaStringSlice.
@@ -677,7 +676,6 @@ impl<'a> PackedDnaStringSet {
         }
     }
 
-
     /// Number of sequences in the set
     pub fn len(&self) -> usize {
         self.start.len()
@@ -695,7 +693,6 @@ impl<'a> PackedDnaStringSet {
         self.length.push(length as u32);
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -793,7 +790,6 @@ mod tests {
         let values: Vec<u8> = suf_dna_string.iter().collect();
         assert_eq!(values, [0, 1, 1, 0]);
 
-
         // 000101000000 64+256
         let suf_dna_string = dna_string.suffix(6).to_owned();
         let values: Vec<u8> = suf_dna_string.iter().collect();
@@ -824,8 +820,8 @@ mod tests {
 
     #[test]
     fn test_kmers() {
-        let dna = "TGCATTAGAAAACTCCTTGCCTGTCAGCCCGACAGGTAGAAACTCATTAATCCACACATTGA".to_string() +
-            "CTCTATTTCAGGTAAATATGACGTCAACTCCTGCATGTTGAAGGCAGTGAGTGGCTGAAACAGCATCAAGGCGTGAAGGC";
+        let dna = "TGCATTAGAAAACTCCTTGCCTGTCAGCCCGACAGGTAGAAACTCATTAATCCACACATTGA".to_string()
+            + "CTCTATTTCAGGTAAATATGACGTCAACTCCTGCATGTTGAAGGCAGTGAGTGGCTGAAACAGCATCAAGGCGTGAAGGC";
         let dna_string = DnaString::from_dna_string(&dna);
 
         let kmers: Vec<IntKmer<u64>> = dna_string.iter_kmers().collect();
@@ -836,7 +832,7 @@ mod tests {
     fn test_ndiffs() {
         let x1 = DnaString::from_dna_string("TGCATTAGAAAACTCCTTGCCTGTCTAGAAACTCATTAATCCACACATTGA");
         let x2 = DnaString::from_dna_string("TGCATTAGTAAACTCCTTCGCTGTCTAGAAAATCATTAAGCCACACATTGA");
-        assert!( ndiffs(&x1, &x2) == 5 );
+        assert!(ndiffs(&x1, &x2) == 5);
     }
 
     #[test]


### PR DESCRIPTION
Tested via `enclone`.  Regression tests pass.  The very large test `enclone.test` now uses ~25% less
time in joining and ~4% less time overall, as measured by wallclock.