### PR TITLE
Speed up bitopts_avx2

### DIFF
--- a/src/bitops_avx2.rs
+++ b/src/bitops_avx2.rs
@@ -9,8 +9,8 @@ pub(crate) unsafe fn pack_32_bases(bases: __m256i) -> u64 {
     // bases = d c b a
 
     let reverse_mask = _mm256_set_epi8(
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+        12, 13, 14, 15,
     );
 
     // step 1: reverse all bytes within lanes

--- a/src/bitops_avx2.rs
+++ b/src/bitops_avx2.rs
@@ -40,12 +40,6 @@ pub(crate) unsafe fn pack_32_bases(bases: __m256i) -> u64 {
     (packed_hi << 32) | packed_lo
 }
 
-#[inline]
-#[target_feature(enable = "avx2")]
-unsafe fn packed_byte(byte: u8) -> __m256i {
-    _mm256_set1_epi8(byte as i8)
-}
-
 /// Convert a slice of 32 ACGT bytes into a __m256i using 0-4 encoding.
 /// Second element in tuple will be false if any of the bases are not in [aAcCgGtT].
 /// Bases not in [aAcCgGtT] will be converted to A / 0.
@@ -53,42 +47,87 @@ unsafe fn packed_byte(byte: u8) -> __m256i {
 pub(crate) unsafe fn convert_bases(bytes: &[u8]) -> (__m256i, bool) {
     assert!(bytes.len() == 32);
 
+    // a lookup table to map a number from 0..128 to a single bit
+    let hi_lut = {
+        let mut lut_hi = 0i64;
+        lut_hi |= 1i64 << ((b'A' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'C' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'G' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'T' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'a' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'c' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b'g' as i64) - 64i64);
+        lut_hi |= 1i64 << ((b't' as i64) - 64i64);
+        _mm256_set_epi64x(lut_hi, 0i64, lut_hi, 0i64)
+    };
+
+    let lo_lut = _mm256_set_epi8(
+        1i8 << 7,
+        1i8 << 6,
+        1i8 << 5,
+        1i8 << 4,
+        1i8 << 3,
+        1i8 << 2,
+        1i8 << 1,
+        1i8 << 0,
+        1i8 << 7,
+        1i8 << 6,
+        1i8 << 5,
+        1i8 << 4,
+        1i8 << 3,
+        1i8 << 2,
+        1i8 << 1,
+        1i8 << 0,
+        1i8 << 7,
+        1i8 << 6,
+        1i8 << 5,
+        1i8 << 4,
+        1i8 << 3,
+        1i8 << 2,
+        1i8 << 1,
+        1i8 << 0,
+        1i8 << 7,
+        1i8 << 6,
+        1i8 << 5,
+        1i8 << 4,
+        1i8 << 3,
+        1i8 << 2,
+        1i8 << 1,
+        1i8 << 0,
+    );
+
+    let lo_mask = _mm256_set1_epi8(0b00001111);
+
+    // convert ACGT (case-insensitive) to a 2-bit representation by looking up low 4 bits
+    let lut = _mm256_set_epi8(
+        0, 0, 0, 0, 0, 0, 0, 0, /* G */ 2, 0, 0, /* T */ 3, /* C */ 1, 0,
+        /* A */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* G */ 2, 0, 0, /* T */ 3,
+        /* C */ 1, 0, /* A */ 0, 0,
+    );
+
     let input = _mm256_loadu_si256(bytes.as_ptr() as *const __m256i);
 
-    let a1 = _mm256_cmpeq_epi8(input, packed_byte(b'a'));
-    let a2 = _mm256_cmpeq_epi8(input, packed_byte(b'A'));
-    let a = _mm256_or_si256(a1, a2);
+    // step 1: lookup a byte using the high 4 bits of each character
+    let hi = _mm256_and_si256(_mm256_srli_epi16(input, 3), lo_mask);
+    let hi_lookup = _mm256_shuffle_epi8(hi_lut, hi);
 
-    let c1 = _mm256_cmpeq_epi8(input, packed_byte(b'c'));
-    let c2 = _mm256_cmpeq_epi8(input, packed_byte(b'C'));
-    let c = _mm256_or_si256(c1, c2);
+    // step 2: convert the low 3 bits of each character to a mask
+    // byte x is converted to (1 << x)
+    let lo_lookup = _mm256_shuffle_epi8(lo_lut, input);
 
-    let g1 = _mm256_cmpeq_epi8(input, packed_byte(b'g'));
-    let g2 = _mm256_cmpeq_epi8(input, packed_byte(b'G'));
-    let g = _mm256_or_si256(g1, g2);
+    // step 3: AND the byte derived from the high 4 bits and the mask derived from the low 3 bits
+    let mask = _mm256_cmpeq_epi8(
+        _mm256_and_si256(lo_lookup, hi_lookup),
+        _mm256_setzero_si256(),
+    );
+    let valid = _mm256_testc_si256(_mm256_setzero_si256(), mask) != 0;
 
-    let t1 = _mm256_cmpeq_epi8(input, packed_byte(b't'));
-    let t2 = _mm256_cmpeq_epi8(input, packed_byte(b'T'));
-    let t = _mm256_or_si256(t1, t2);
+    // step 4: use lookup table to convert nucleotides to their 2-bit representation,
+    // while zeroing out invalid characters (shuffle returns a zero byte if MSB of a byte is 1)
+    let shuffled = _mm256_shuffle_epi8(lut, input);
+    let res = _mm256_andnot_si256(mask, shuffled);
 
-    let mut res = packed_byte(0);
-    let mut valid = packed_byte(0);
-
-    res = _mm256_blendv_epi8(res, packed_byte(0), a);
-    valid = _mm256_or_si256(valid, a);
-
-    res = _mm256_blendv_epi8(res, packed_byte(1), c);
-    valid = _mm256_or_si256(valid, c);
-
-    res = _mm256_blendv_epi8(res, packed_byte(2), g);
-    valid = _mm256_or_si256(valid, g);
-
-    res = _mm256_blendv_epi8(res, packed_byte(3), t);
-    valid = _mm256_or_si256(valid, t);
-
-    let vv = _mm256_testc_si256(valid, packed_byte(255));
-
-    return (res, vv == 1);
+    (res, valid)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Goals:
- [x] Speed up packing two-bit encoded nucleotides from 32 bytes to a single 64-bit integer. Ideas: fold bit reversal step into the permutes for the packing process and use a simpler movemask method for packing bits ([inspiration](https://github.com/Daniel-Liu-c0deb0t/cute-nucleotides), more specifically the movemask idea proposed by aqrit).
- [x] Speed up checking and converting characters to two-bit encoded nucleotides. Ideas: use bit lookup table with 128 entries, based on [this](https://github.com/natir/nuc2bit/blob/master/src/check.rs) thing I recently wrote.