### PR TITLE
Replace `num` with `num_traits`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 
 
 [dependencies]
+num-traits=">=0.2"
 serde = "^1"
 serde_derive = "^1"
 serde_json = "^1"
 smallvec = "1"
 bit-set = "0.5.1"
 itertools = ">=0.7"
-num = ">=0.2, <0.5"
 log = "0.4"
 
 [dev-dependencies]

--- a/src/kmer.rs
+++ b/src/kmer.rs
@@ -33,8 +33,8 @@
 //!         Kmer16::from_ascii(b"TACGTACGTACGTACG")
 //!     ]);
 
-use num::FromPrimitive;
-use num::PrimInt;
+use num_traits::FromPrimitive;
+use num_traits::PrimInt;
 use serde_derive::{Deserialize, Serialize};
 use std;
 use std::fmt;


### PR DESCRIPTION
From the docs: `num is a meta-crate, re-exporting items from these sub-crates:`

We only seem to use one of those sub-crates, and some of the others don't compile on Rust nightly, hence sliming down the dependency.